### PR TITLE
Improve `komet test` UI with progress bar and failure reporting

### DIFF
--- a/src/komet/komet.py
+++ b/src/komet/komet.py
@@ -20,7 +20,7 @@ from pyk.utils import abs_or_rel_to, ensure_dir_path
 from pykwasm.scripts.preprocessor import preprocess
 
 from .kasmer import Kasmer
-from .utils import concrete_definition, symbolic_definition
+from .utils import KSorobanError, concrete_definition, symbolic_definition
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -101,9 +101,11 @@ def _exec_test(*, dir_path: Path | None, wasm: Path | None, max_examples: int, i
         child_wasms = _read_config_file(kasmer, dir_path)
         wasm = kasmer.build_soroban_contract(dir_path)
 
-    kasmer.deploy_and_run(wasm, child_wasms, max_examples, id)
-
-    sys.exit(0)
+    try:
+        kasmer.deploy_and_run(wasm, child_wasms, max_examples, id)
+        sys.exit(0)
+    except KSorobanError:
+        sys.exit(1)
 
 
 def _exec_prove_run(

--- a/src/tests/integration/test_integration.py
+++ b/src/tests/integration/test_integration.py
@@ -6,7 +6,7 @@ from pyk.ktool.krun import _krun
 
 from komet.kasmer import Kasmer
 from komet.komet import _read_config_file
-from komet.utils import concrete_definition, symbolic_definition
+from komet.utils import KSorobanError, concrete_definition, symbolic_definition
 
 TEST_DATA = (Path(__file__).parent / 'data').resolve(strict=True)
 TEST_FILES = TEST_DATA.glob('*.wast')
@@ -40,7 +40,7 @@ def test_komet(contract_path: Path, tmp_path: Path, concrete_kasmer: Kasmer) -> 
 
     # Then
     if contract_path.stem.endswith('_fail'):
-        with pytest.raises(AssertionError):
+        with pytest.raises(KSorobanError):
             concrete_kasmer.deploy_and_run(contract_wasm, child_wasms)
     else:
         concrete_kasmer.deploy_and_run(contract_wasm, child_wasms)


### PR DESCRIPTION
This PR enhances the UI of `komet test` by adding a progress bar and failure reporting. The progress bar displays test completion, total tests, elapsed time, and pass/fail status. After execution, failed tests are listed with their falsifying examples.

In progress:

![progress2](https://github.com/user-attachments/assets/d10b6140-e902-4b12-887f-2c100cb3f0b7)

Finished:

![progress](https://github.com/user-attachments/assets/4da8e8ab-dfba-4647-b18d-45579ebe0d13)

Failed:

![progress_failed](https://github.com/user-attachments/assets/911b964e-ee4f-42cb-a46d-3895670881ff)
