### PR TITLE
Optimize fuzzing using targeted substitution

### DIFF
--- a/src/komet/kasmer.py
+++ b/src/komet/kasmer.py
@@ -42,7 +42,7 @@ from .kast.syntax import (
 )
 from .proof import is_functional, run_claim, run_functional_claim
 from .scval import SCType
-from .utils import KSorobanError, concrete_definition
+from .utils import KSorobanError, concrete_definition, subst_on_program_cell
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Mapping
@@ -248,6 +248,7 @@ class Kasmer:
             check_exit_code=True,
             max_examples=max_examples,
             handler=KometFuzzHandler(self.definition, task),
+            subst_func=subst_on_program_cell,
         )
 
     def run_prove(


### PR DESCRIPTION


This PR improves performance by optimizing the substitution algorithm in the fuzzer. Substitutions now target only the `<program>` cell via the `subst_func` parameter in `fuzz`. This prevents the substitution from needlessly traversing these large terms, leading to a 3x speedup in fuzzing.

The speedup was measured using the existing test suite, particularly the FxDAO tests. In cases where the initial state is larger—such as tests involving multiple contracts or bigger contracts—the performance improvement is even more significant.