### PR TITLE
Add module interface for CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /dist/
 __pycache__/
 .coverage
+.python-version

--- a/src/komet/__main__.py
+++ b/src/komet/__main__.py
@@ -1,0 +1,5 @@
+import sys
+from komet.komet import main
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
It can be difficult to attach a debugger to a bash launch script. This is certainly the case with debugpy and its VS Code integration. A module that loads the CLI solves this problem.

I like to provide this interface on the main module. Of course, that's a matter of preference, and I'm happy to put it elsewhere.

To illustrate, this PR lets me easily launch `komet` with any command-line arguments from my contracts repo. All within the convenience of my IDE without any context switching.

Example `launch.json` entry for VScode:

```json
    {
      "name": "Debug komet with debugpy",
      "type": "debugpy",
      "request": "launch",
      "cwd": "${workspaceFolder}/contracts/komet-sink-carbon",
      "module": "komet",
      "args": "${command:pickArgs}",
      "console": "integratedTerminal",
      "justMyCode": false,
      "env": {
        // TODO: get from ~/.nix-profile/bin/komet or build soroban-semantics
        "KDIST_DIR": "/nix/store/1afdx3dnkb3j0ln7q62hpfs3hy2i3s8p-komet-9211c581bf6e92094819a8e99b55c85e23dc7c8b"
      }
    }
```